### PR TITLE
ESP32 Voltage Divider and A2 Pin

### DIFF
--- a/solar-battery-charger.ino
+++ b/solar-battery-charger.ino
@@ -39,7 +39,7 @@
 #if defined(ESP8266)
   #define ANALOG_PIN_NO A0      // analog pin number
 #elif defined(ESP32)
-  #define ANALOG_PIN_NO A13     // analog pin number
+  #define ANALOG_PIN_NO A2     // analog pin number
 #endif
 #define BAUD_RATE 115200        // baud rate used for Serial console
 #define R1 1000000              // resistor 1 on the voltage divider (Ω)
@@ -96,14 +96,14 @@ unsigned int localPort = 8888;  // local port to listen for UDP packets
 const int ledPin = LED_BUILTIN;
 
 // calculate the voltage divider ratio
-float resistor_ratio=(float)R2/((float)R1+(float)R2);
+//float resistor_ratio=(float)R2/((float)R1+(float)R2);
 
 // calculate the min battery number using the resistor ratio
-int battery_min=(float)resistor_ratio*(float)VOLTAGE_MIN*1024;
+//int battery_min=(float)resistor_ratio*(float)VOLTAGE_MIN*1024;
 //int battery_min=580;
 
 // calculate the max battery number using the resistor ratio
-int battery_max=(float)resistor_ratio*(float)VOLTAGE_MAX*1024;
+//int battery_max=(float)resistor_ratio*(float)VOLTAGE_MAX*1024;
 //int battery_max=774;
 
 const int dst = timeZone+1;

--- a/src/Battery.h
+++ b/src/Battery.h
@@ -58,21 +58,12 @@ class Battery{
 
     int percentage(){
       // convert battery level to percent
-      #if defined(ESP8266)
-        int percentage = map(level(), _level_min, _level_max, 0, 100);
-      #elif defined(ESP32)
-        int percentage = (float)level()*2/1000/(float)_voltage_max*100;
-      #endif
+      int percentage = map(level(), _level_min, _level_max, 0, 100);
       return percentage;
     }
 
     float voltage(){
-      // convert battery level to voltage
-      #if defined(ESP8266)
-        float voltage = (float)map(level(), _level_min, _level_max, _voltage_min*100, _voltage_max*100)/100;
-      #elif defined(ESP32)
-        float voltage = (float)level()*2/1000;
-      #endif
+      float voltage = (float)map(level(), _level_min, _level_max, _voltage_min*100, _voltage_max*100)/100;
       return voltage;
     }
 };


### PR DESCRIPTION
Change ESP32 analog pin to A2 from A0 because ADC 2 on the HUZZAH32 turns off once connected to WiFi. See [FAQ](https://learn.adafruit.com/adafruit-huzzah32-esp32-feather/esp32-faq#faq-2991123)

Add voltage divider to ESP32 because connecting the ESP32 BAT pin to the bq24074 causes the Feather to reboot perhaps because of power cycling. Need to connect the Feather to the bq24074 output which means that the internal battery reading does not read the battery levels.